### PR TITLE
Fixed `convertPoint(fromViewPoint:)` return value

### DIFF
--- a/UIImageView-GeometryConvesion.swift
+++ b/UIImageView-GeometryConvesion.swift
@@ -129,7 +129,7 @@ extension UIImageView {
 			break
 		}
 		
-		return viewPoint
+		return imagePoint
 	}
 	
 	func convertRect(fromViewRect viewRect : CGRect) -> CGRect {


### PR DESCRIPTION
It should return an `imagePoint` not `viewPoint`.